### PR TITLE
Stop appending global config

### DIFF
--- a/autoload/doppelganger.vim
+++ b/autoload/doppelganger.vim
@@ -159,8 +159,8 @@ function! s:set_pairs() abort "{{{2
   endif
 
   let pairs = has_key(g:doppelganger#pairs, &ft)
-        \ ? g:doppelganger#pairs[&ft]
-        \ : g:doppelganger#pairs['_']
+        \ ? deepcopy(g:doppelganger#pairs[&ft])
+        \ : deepcopy(g:doppelganger#pairs['_'])
   if exists('b:match_words')
     let pairs += s:parse_matchwords()
     let pairs = sort(pairs, 's:sort_by_length_desc')

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -66,7 +66,16 @@ b:doppelganger_pairs					  *b:doppelganger_pairs*
 	Set in |Dict|.
 	Each key should represent a filetype; '_' is a special key for the
 	rest of filetypes specified in the keys.
-	The actual pairs detected will be improved if |b:match_words| exists.
+
+	|Doppelganger| will parse |b:match_words|, if it exists, and will
+	convert it with |g:doppelganger#pairs| (as the key) to
+	|b:doppelganger_pairs|.  After all, |Doppelganger| will try to search
+	pairs to set visualtexts as |b:doppelganger_pairs| unless current
+	filetype is set to |g:doppelganger#ego#disable_on_filetypes|.
+
+	Note:
+	You can also set |b:doppelganger_pairs| manually.  It must be set in
+	|List|, not in |Dict|.
 
 g:doppelganger#skip_hl_groups			 *g:doppelganger#skip_hl_groups*
 	(default: {

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -60,7 +60,7 @@ g:doppelganger#conceal_the_other_end_pattern
 <
 g:doppelganger#pairs					  *g:doppelganger#pairs*
 	(default: {
-		\ '_': ['{', '}'], ['(', ')'], ['\[', ']'],
+		\ '_': [['{', '}'], ['(', ')'], ['\[', ']']],
 		\ })
 	Set in |Dict|.
 	Each key should represent a filetype; '_' is a special key for the

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -59,6 +59,7 @@ g:doppelganger#conceal_the_other_end_pattern
 	}
 <
 g:doppelganger#pairs					  *g:doppelganger#pairs*
+b:doppelganger_pairs					  *b:doppelganger_pairs*
 	(default: {
 		\ '_': [['{', '}'], ['(', ')'], ['\[', ']']],
 		\ })

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -1,4 +1,4 @@
-*doppelganger.txt*
+*doppelganger.txt* *doppelganger* *Doppelganger* *DoppelGanger*
 
 Version: 1.0.0
 Author: kaile256 <kaile256acc at gmail.com>
@@ -17,8 +17,6 @@ Compatibility		|doppelganger-compatibility|
 
 ==============================================================================
 INTRODUCTION					     *doppelganger-introduction*
-
-	*doppelganger*
 
 Latest version:
 https://github.com/kaile256/vim-doppelganger


### PR DESCRIPTION
Before the PR, doppelganger update g:doppelganger#pairs carelessly.

Addition to that, describe the process of parsing config how to get wanted b:doppelganger_pairs in the documentation.