### PR TITLE
test(os): run test on ubuntu-latest at the last

### DIFF
--- a/.github/workflows/vimscript.yml
+++ b/.github/workflows/vimscript.yml
@@ -30,9 +30,9 @@ jobs:
         nvim_version:
           - nightly
         os:
-          - ubuntu-latest
           - macos-latest
           - windows-latest
+          - ubuntu-latest # Currently, out-of-date to build neovim.
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Because ubuntu-latest is out-of-date to build neovim of the released tar.