### PR TITLE
perf!(config): remove g:...#min_range_of_pairs

### DIFF
--- a/autoload/doppelganger.vim
+++ b/autoload/doppelganger.vim
@@ -56,7 +56,7 @@ function! doppelganger#update(upper, lower, ...) abort "{{{1
   "}}}
 
   call doppelganger#clear()
-  let min_range = a:0 > 0 ? a:1 : g:doppelganger#min_range_of_pairs
+  let min_range = get(a:, 1, 0)
   call s:deploy_doppelgangers(a:upper, a:lower, min_range)
 endfunction
 

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -117,15 +117,6 @@ b:doppelganger_hl_groups_to_skip	      *b:doppelganger_hl_groups_to_skip*
 	Each key should represent a filetype; '_' is a special key for the
 	rest of filetypes specified in the keys.
 
-g:doppelganger#min_range_of_pairs	     *g:doppelganger#min_range_of_pairs*
-	(default: 1)
-	Set in |Number|.
-	Minimum range of pairs to set virtualtext.
-	Set 0 to show virtualtext even when a pair is in the same line.
-	This variable is ignored in ego-feature.
-
-	See also |g:doppelganger#ego#min_range_of_pairs|.
-
 g:doppelganger#ego#disable_autostart	  *g:doppelganger#ego#disable_autostart*
 	(default: 0)
 	Set in |Number|.
@@ -160,8 +151,6 @@ g:doppelganger#ego#min_range_of_pairs    *g:doppelganger#ego#min_range_of_pairs*
 	Minimum range of pairs to set virtualtext.
 	Set 0 to show virtualtext even when a pair is in the same line.
 	This variable is only for ego-feature.
-
-	See also |g:doppelganger#min_range_of_pairs|.
 
 g:doppelganger#ego#max_offset			 *g:doppelganger#ego#max_offset*
 	(default: 3)
@@ -243,6 +232,8 @@ COMPATIBILITY					    *doppelganger-compatibility*
 * Remove the feature to conceal pattern up to pair and
   g:doppelganger#conceal_the_other_end_pattern which's meaningless now
   that contents in pairs are shown instead.
+* Remove doppelganger#min_range_of_pairs which was just confusing with
+  g:doppelganger#ego#min_range_of_pairs but has little need.
 
 2020-12-05
 * Rename g:doppelganger#pairs to g:doppelganger#search#pairs.

--- a/plugin/doppelganger.vim
+++ b/plugin/doppelganger.vim
@@ -67,7 +67,6 @@ call s:set_default('g:doppelganger#hl_groups_to_skip', {
       \ 'json': [
       \   'jsonKeyword',
       \ ]})
-call s:set_default('g:doppelganger#min_range_of_pairs', 1)
 
 call s:set_default('g:doppelganger#ego#disable_autostart', 0)
 call s:set_default('g:doppelganger#ego#disable_on_buftypes', [


### PR DESCRIPTION
The variable was just confusing with
g:doppelganger#ego#min_range_of_pairs but has little need.