### PR TITLE
perf(search): reduce unnecessary regex patterns

### DIFF
--- a/autoload/doppelganger/search.vim
+++ b/autoload/doppelganger/search.vim
@@ -165,39 +165,13 @@ function! s:get_outmost_pair(lnum) abort "{{{1
 
   for p in pairs
     let pat_close = p[-1]
-    let pat_close_at_endOfLine = s:append_endOfLine_pattern(pat_close)
-    let match = matchstr(line, pat_close_at_endOfLine)
+    " Tips: appending <NL> matches as if '$' is, with any magics like '\v'.
+    let match = matchstr(line ."\n", pat_close ."\n")
     if len(match)
       return p
     endif
   endfor
 
   return []
-endfunction
-
-function! s:append_endOfLine_pattern(pat) abort "{{{1
-  let separators_at_end = ',;'
-
-  " Sample: to get correct pattern
-  " $
-  " \$
-  let pat_at_end = ''
-  if a:pat =~# '\\v'
-    let pat_at_end = a:pat =~# '\\\@<!$$'
-          \ ? ''
-          \ : '['. separators_at_end .']?$'
-  elseif a:pat =~# '\\V'
-    let pat_at_end = a:pat =~# '\\$$'
-          \ ? ''
-          \ : '\['. separators_at_end .']\?\$'
-  elseif a:pat =~# '\\M'
-    let pat_at_end = a:pat =~# '\\\@<!$$'
-          \ ? ''
-          \ : '\['. separators_at_end .']\?$'
-  elseif a:pat !~# '\\\@<!$$'
-    let pat_at_end = '['. separators_at_end .']\?$'
-  endif
-
-  return a:pat . pat_at_end
 endfunction
 

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -79,8 +79,12 @@ g:doppelganger#search#pairs			  *g:doppelgangersearch##pairs*
 b:doppelganger_search_pairs			  *b:doppelganger_search_pairs*
 b:_doppelganger_search_pairs			 *b:_doppelganger_search_pairs*
 	(default: {
-		\ '_': [['{', '}'], ['(', ')'], ['\[', ']']],
+		\ '_': [
+		\	['{', '}[,;]\?'],
+		\	['(', ')[,;'\?],
+		\	['\[', '\][,;'\?]],
 		\ })
+
 	Set in |Dict|.
 	|Doppelganger| will search pairs to set visualtexts as these variables.
 

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -81,8 +81,9 @@ b:_doppelganger_search_pairs			 *b:_doppelganger_search_pairs*
 	(default: {
 		\ '_': [
 		\	['{', '}[,;]\?'],
-		\	['(', ')[,;'\?],
-		\	['\[', '\][,;'\?]],
+		\	['(', ')[,;]\?]',
+		\	['\[', '\][,;]\?']
+		\	],
 		\ })
 
 	Set in |Dict|.

--- a/plugin/doppelganger.vim
+++ b/plugin/doppelganger.vim
@@ -50,10 +50,10 @@ call s:set_default('g:doppelganger#text#compress_whitespaces', 1)
 call s:set_default('g:doppelganger#text#max_column_width', max([&tw, 79]))
 call s:set_default('g:doppelganger#search#pairs', {
       \ '_': [
-      \   ['{', '}'],
-      \   ['(', ')'],
-      \   ['\[', ']'],
-      \ ],
+      \   ['{', '}[,;]\?'],
+      \   ['(', ')[,;]\?'],
+      \   ['\[', '\][,;]\?'],
+      \   ],
       \ })
 call s:set_default('g:doppelganger#search#pairs_reverse', {
       \ '_': [


### PR DESCRIPTION
# Excerpts of evidences
- A commits which removed `s:append_EndOfLine_pattern()` reduces the speed to `0.551483 (= 0.697728 / 1.265184)` in ratio to get the outmost pair in lines.
### Old -- regex is included
![old regex including one](https://user-images.githubusercontent.com/46470475/102705271-0b471680-42c9-11eb-9b67-210a1665640f.png)
### New -- regex is reduced
![new regex reduced one](https://user-images.githubusercontent.com/46470475/102705266-f4a0bf80-42c8-11eb-90c9-c479b81756eb.png)

