### PR TITLE
Tidy up ego

### DIFF
--- a/autoload/doppelganger/ego.vim
+++ b/autoload/doppelganger/ego.vim
@@ -58,7 +58,7 @@ function! doppelganger#ego#is_enabled() abort "{{{1
 endfunction
 
 function! doppelganger#ego#disable() abort "{{{1
-  augroup doppelganger
+  augroup doppelganger/ego
     au!
   augroup END
   let save_winID = win_getid()
@@ -68,7 +68,7 @@ function! doppelganger#ego#disable() abort "{{{1
 endfunction
 
 function! doppelganger#ego#enable() abort "{{{1
-  augroup doppelganger
+  augroup doppelganger/ego
     au!
 
     au WinLeave * call doppelganger#clear()

--- a/autoload/doppelganger/ego.vim
+++ b/autoload/doppelganger/ego.vim
@@ -69,7 +69,6 @@ endfunction
 
 function! doppelganger#ego#enable() abort "{{{1
   call s:windo_update()
-  let events = join(s:get_config('update_events'), ',')
   augroup doppelganger
     au!
 
@@ -84,7 +83,8 @@ function! doppelganger#ego#enable() abort "{{{1
           \   {'region': 'Haunt'},
           \ ])
 
-    exe 'au' events '* call s:update_window()'
+    au BufWinEnter    * call s:update_window()
+    au TextChanged * call s:update_window()
 
     if s:get_config('update_on_CursorMoved')
       let s:last_lnum = line('.')

--- a/autoload/doppelganger/ego.vim
+++ b/autoload/doppelganger/ego.vim
@@ -68,7 +68,6 @@ function! doppelganger#ego#disable() abort "{{{1
 endfunction
 
 function! doppelganger#ego#enable() abort "{{{1
-  call s:windo_update()
   augroup doppelganger
     au!
 
@@ -101,14 +100,6 @@ function! doppelganger#ego#toggle() abort "{{{1
     return
   endif
   call doppelganger#ego#enable()
-endfunction
-
-function! s:windo_update() abort "{{{1
-  let save_winID = win_getid()
-
-  windo call s:update_window()
-
-  call win_gotoid(save_winID)
 endfunction
 
 function! s:update_for_CursorMoved() abort "{{{2

--- a/autoload/doppelganger/ego.vim
+++ b/autoload/doppelganger/ego.vim
@@ -83,7 +83,7 @@ function! doppelganger#ego#enable() abort "{{{1
           \   {'region': 'Haunt'},
           \ ])
 
-    au BufWinEnter    * call s:update_window()
+    au WinEnter    * call s:update_window()
     au TextChanged * call s:update_window()
 
     if s:get_config('update_on_CursorMoved')

--- a/doc/doppelganger.txt
+++ b/doc/doppelganger.txt
@@ -185,15 +185,6 @@ g:doppelganger#ego#max_offset			 *g:doppelganger#ego#max_offset*
 	Set in |Number|.
 	|doppelganger| will try to set virtualtext in the offset around cursor.
 
-g:doppelganger#ego#update_events	      *g:doppelganger#ego#update_events*
-	(default: ['BufWinEnter', 'TextChanged'])
-	Set in |List|.
-	It's recommended to update by |autocmd|s via this variable.
-
-	Note:
-	It's deprecated to set |CursorMoved| in this variable.
-	See also |g:doppelganger#ego#update_on_CursorMoved|.
-
 				      *g:doppelganger#ego#update_on_CursorMoved*
 g:doppelganger#ego#update_on_CursorMoved
 	(default: 1)
@@ -252,6 +243,7 @@ COMPATIBILITY					    *doppelganger-compatibility*
 * Remove old commands, :DoppelgangerUpdate, :DoppelgangerClear,
   :DoppelgangerToggle, :DoppelgangerEgoEnable :DoppelgangerEgoDisable and
   :DoppelgangerEgoToggle. and just define a command, :Doppelganger.
+* Remove g:doppelganger#ego#update_events.
 
 2020-12-10
 * Rename g:doppelganger#prefix to g:doppelganger#text#prefix.

--- a/plugin/doppelganger.vim
+++ b/plugin/doppelganger.vim
@@ -96,10 +96,6 @@ call s:set_default('g:doppelganger#ego#disable_on_filetypes', [
 
 call s:set_default('g:doppelganger#ego#min_range_of_pairs', 4)
 call s:set_default('g:doppelganger#ego#max_offset', 3)
-call s:set_default('g:doppelganger#ego#update_events', [
-      \ 'BufWinEnter',
-      \ 'TextChanged',
-      \ ])
 call s:set_default('g:doppelganger#ego#update_on_CursorMoved', 1)
 
 call s:set_default('g:doppelganger#mapping#fold_suffixes', 'voraxcmORAXCM')


### PR DESCRIPTION
1. Remove `g:doppelganger#ego#update_events` because it's hard to manage unexpected events.
2. Remove useless `s:windo_update()`.
3. Rename au-event name: `doppelganger` to `doppelganger/ego`.