### PR TITLE
fix(cache): drop caches in haunt.vim

### DIFF
--- a/autoload/doppelganger/ego.vim
+++ b/autoload/doppelganger/ego.vim
@@ -73,17 +73,9 @@ function! doppelganger#ego#enable() abort "{{{1
 
     au WinLeave * call doppelganger#clear()
 
-    " Define au-commands in different lines to each events because cache which
-    " should be updated could be different between each events.
-    au BufWinLeave * call s:Cache.DropOutdated([
-          \   {'region': 'Haunt'},
-          \ ])
-    au TextChanged * call s:Cache.DropOutdated([
-          \   {'region': 'Haunt'},
-          \ ])
-
-    au WinEnter    * call s:update_window()
-    au TextChanged * call s:update_window()
+    au WinEnter     * call s:update_window()
+    au TextChanged  * call s:update_window()
+    au TextChangedI * call s:update_window()
 
     if s:get_config('update_on_CursorMoved')
       let s:last_lnum = line('.')

--- a/autoload/doppelganger/haunt.vim
+++ b/autoload/doppelganger/haunt.vim
@@ -135,3 +135,24 @@ function! s:is_folded(lnum) abort "{{{2
 endfunction
 
 
+augroup doppelganger/haunt
+  au!
+  au BufWinLeave * call s:Cache.DropOutdated([
+        \   {
+        \   'region': 'Haunt',
+        \   'name':   'chunks',
+        \   },
+        \ ])
+  au TextChanged * call s:Cache.DropOutdated([
+        \   {
+        \   'region': 'Haunt',
+        \   'name':   'chunks',
+        \   },
+        \ ])
+  au TextChangedI * call s:Cache.DropOutdated([
+        \   {
+        \   'region': 'Haunt',
+        \   'name':   'chunks',
+        \   },
+        \ ])
+augroup END


### PR DESCRIPTION
Before this commit, no caches would be updated while editing, when users don't enable `ego`.

- Move the `autocmd`s to drop caches into `haunt.vim`.
- Add `TextChangedI` to drop cache.
- Insert `{'name': 'chunks'}` to limit type to drop caches.