### PR TITLE
test: clear cache before each tests

### DIFF
--- a/test/.themisrc
+++ b/test/.themisrc
@@ -37,14 +37,15 @@ function! s:doppelganger_set_simplest_decorations() abort
   let g:doppelganger#format#max_column_width = 80
 endfunction
 
-function! s:doppelganger_set_simplest_state() abort
+function! s:doppelganger_reset_state() abort
   call s:doppelganger_set_simplest_decorations()
   Doppelganger ego/disable
   Doppelganger clear
+  Doppelganger cache/clear
 endfunction
 
 command! DoppelgangerSetSimplestDecorations :call s:doppelganger_set_simplest_decorations()
-command! DoppelgangerSetSimplestState :call s:doppelganger_set_simplest_state()
+command! DoppelgangerResetState :call s:doppelganger_reset_state()
 
 
 function! s:init_buffer() abort

--- a/test/00-prerequisite/20-themis.vimspec
+++ b/test/00-prerequisite/20-themis.vimspec
@@ -1,7 +1,7 @@
 Describe 00-Prerequisite -- 20-Themis:
   Before each
     InitBuffer
-    DoppelgangerSetSimplestState
+    DoppelgangerResetState
   End
 
   Context GetVirtualTextsAsPlainTexts()

--- a/test/10-unit_test/20-Components.vimspec
+++ b/test/10-unit_test/20-Components.vimspec
@@ -1,6 +1,6 @@
 Describe 10-Unit-Test -- Components
   Before each
-    DoppelgangerSetSimplestState
+    DoppelgangerResetState
 
     const default_context = [
           \ 'int main() {',

--- a/test/10-unit_test/50-haunt.vimspec
+++ b/test/10-unit_test/50-haunt.vimspec
@@ -1,7 +1,7 @@
 Describe 10-Unit-Test -- Haunt
   Before each
     InitBuffer
-    DoppelgangerSetSimplestState
+    DoppelgangerResetState
   End
 
   Before all

--- a/test/80-command/80-update.vimspec
+++ b/test/80-command/80-update.vimspec
@@ -1,7 +1,7 @@
 Describe 80-Command -- `:Doppelganger update`
   Before each
     InitBuffer
-    DoppelgangerSetSimplestState
+    DoppelgangerResetState
   End
 
   Context in a cpp-like file


### PR DESCRIPTION
Keep clean the state of doppelganger, to reduce dependencies.